### PR TITLE
Fixed first synchronization attempt failing after reparenting dataset…

### DIFF
--- a/CognitoSync/Custom/SyncManager/_unity/CognitoSyncManager.cs
+++ b/CognitoSync/Custom/SyncManager/_unity/CognitoSyncManager.cs
@@ -172,7 +172,7 @@ namespace Amazon.CognitoSync.SyncManager
             Amazon.CognitoIdentity.CognitoAWSCredentials.IdentityChangedArgs identityChangedEvent = e as Amazon.CognitoIdentity.CognitoAWSCredentials.IdentityChangedArgs;
             if (identityChangedEvent.NewIdentityId != null)
             {
-                String oldIdentity = identityChangedEvent.OldIdentityId == null ? DatasetUtils.UNKNOWN_IDENTITY_ID : identityChangedEvent.OldIdentityId;
+                String oldIdentity = string.IsNullOrEmpty(identityChangedEvent.OldIdentityId) ? DatasetUtils.UNKNOWN_IDENTITY_ID : identityChangedEvent.OldIdentityId;
                 String newIdentity = identityChangedEvent.NewIdentityId;
                 _logger.InfoFormat("Identity changed from {0} to {1}", oldIdentity, newIdentity);
                 Local.ChangeIdentityId(oldIdentity, newIdentity);


### PR DESCRIPTION
… from "unknown" identity ID.

Steps to reproduce:
1. Delete identity in Cognito console, if exists.
2. Delete file c:\Users<user>\AppData\LocalLow<company><projectname>\aws_cognito_cache.db, if exists.
3. Run code:

```
PlayerPrefs.DeleteAll();
var credentials = new CognitoAWSCredentials(poolId, region);
var clientConfig = new AmazonCognitoSyncConfig { RegionEndpoint = region };
var syncManager = new CognitoSyncManager(credentials, clientConfig);
var dataset = syncManager.OpenOrCreateDataset(datasetName);
dataset.OnSyncSuccess += OnSyncSuccess;
dataset.Put("myInt", "5");
credentials.AddLogin("graph.facebook.com", accessToken);
credentials.GetIdentityIdAsync(result =>
{
    string myInt = dataset.Get("myInt");
    Debug.Log("myInt is <" + myInt + ">");

    // reparenting from unknown to eu-west*** failed
    // myInt is empty string, but expected "5"

    dataset.Synchronize(); // OnSyncSuccess is raised but dataset will not be created in Cognito console.
});
```

**Logs before fix:**
Cognito Sync - SQLiteStorage - running create dataset
Cognito Sync - SQLiteStorage - running create dataset
Cognito Sync - SQLiteStorage - completed setupdatabase
recieved successful response
{"IdentityId":"eu-west_"}
Identity changed from  to eu-west_
Reparenting datasets from  to eu-west*
myInt is <>
get latest modified records since 0 for dataset myDataset
...
localChanges.Count 0
OnSyncSuccess

**Logs after fix:**
Cognito Sync - SQLiteStorage - running create dataset
Cognito Sync - SQLiteStorage - running create dataset
Cognito Sync - SQLiteStorage - completed setupdatabase
recieved successful response
{"IdentityId":"eu-west_"}
Identity changed from unknown to eu-west_
Reparenting datasets from unknown to eu-west*
myInt is <5>
get latest modified records since 0 for dataset myDataset
...
localChanges.Count 1
push 1 records to remote
...
updated sync count 1
OnSyncSuccess
